### PR TITLE
[Feat]: Naver 검색 API 활용 관심 상품 등록 API, 희망 최저가 설정 API 구현

### DIFF
--- a/src/main/java/com/sparta/myselectshop/MyselectshopApplication.java
+++ b/src/main/java/com/sparta/myselectshop/MyselectshopApplication.java
@@ -2,7 +2,9 @@ package com.sparta.myselectshop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MyselectshopApplication {
 

--- a/src/main/java/com/sparta/myselectshop/controller/ProductController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/ProductController.java
@@ -1,14 +1,14 @@
 package com.sparta.myselectshop.controller;
 
+import com.sparta.myselectshop.dto.ProductMypriceRequestDto;
 import com.sparta.myselectshop.dto.ProductRequestDto;
 import com.sparta.myselectshop.dto.ProductResponseDto;
 import com.sparta.myselectshop.service.ProductService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api")
@@ -20,5 +20,12 @@ public class ProductController {
     @PostMapping("/products")
     public ProductResponseDto createProduct(@RequestBody ProductRequestDto requestDto) {
         return productService.createProduct(requestDto);
+    }
+
+    // 관심상품 희망 최저가 업데이트 API
+    @PutMapping("/products/{id}")
+    public ProductResponseDto updateProduct(@PathVariable Long id, @RequestBody ProductMypriceRequestDto requestDto) {
+        log.info("관심상품 희망 최저가 업데이트 API 컨트롤러 요청!!!!!!!!!!!!!!");
+        return productService.updateProduct(id, requestDto);
     }
 }

--- a/src/main/java/com/sparta/myselectshop/controller/ProductController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/ProductController.java
@@ -1,0 +1,24 @@
+package com.sparta.myselectshop.controller;
+
+import com.sparta.myselectshop.dto.ProductRequestDto;
+import com.sparta.myselectshop.dto.ProductResponseDto;
+import com.sparta.myselectshop.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class ProductController {
+
+    private final ProductService productService;
+
+    // 관심상품 등록 API
+    @PostMapping("/products")
+    public ProductResponseDto createProduct(@RequestBody ProductRequestDto requestDto) {
+        return productService.createProduct(requestDto);
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/dto/ProductMypriceRequestDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/ProductMypriceRequestDto.java
@@ -1,0 +1,8 @@
+package com.sparta.myselectshop.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProductMypriceRequestDto {
+    private int myprice;
+}

--- a/src/main/java/com/sparta/myselectshop/dto/ProductRequestDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/ProductRequestDto.java
@@ -1,0 +1,19 @@
+package com.sparta.myselectshop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductRequestDto {
+    // 관심 상품명
+    private String title;
+    // 관심상품 썸네일
+    private String image;
+    // 관심상품 구매 링크 URL
+    private String link;
+    // 관심상품의 최저가
+    private int lprice;
+}

--- a/src/main/java/com/sparta/myselectshop/dto/ProductResponseDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/ProductResponseDto.java
@@ -1,0 +1,22 @@
+package com.sparta.myselectshop.dto;
+
+import com.sparta.myselectshop.entity.Product;
+
+
+public class ProductResponseDto {
+    private Long id;
+    private String title;
+    private String link;
+    private String image;
+    private int lprice;
+    private int myprice;
+
+    public ProductResponseDto(Product product) {
+        this.id = product.getId();
+        this.title = product.getTitle();
+        this.link = product.getLink();
+        this.image = product.getImage();
+        this.lprice = product.getLprice();
+        this.myprice = product.getMyprice();
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/dto/ProductResponseDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/ProductResponseDto.java
@@ -1,8 +1,11 @@
 package com.sparta.myselectshop.dto;
 
 import com.sparta.myselectshop.entity.Product;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-
+@Getter
+@NoArgsConstructor
 public class ProductResponseDto {
     private Long id;
     private String title;

--- a/src/main/java/com/sparta/myselectshop/entity/Product.java
+++ b/src/main/java/com/sparta/myselectshop/entity/Product.java
@@ -1,5 +1,6 @@
 package com.sparta.myselectshop.entity;
 
+import com.sparta.myselectshop.dto.ProductMypriceRequestDto;
 import com.sparta.myselectshop.dto.ProductRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
@@ -36,5 +37,10 @@ public class Product extends TimeStamped {
         this.image = requestDto.getImage();
         this.link = requestDto.getLink();
         this.lprice = requestDto.getLprice();
+    }
+
+    // 관심상품의 희망 최저가 설정 메서드
+    public void update(ProductMypriceRequestDto requestDto) {
+        this.myprice = requestDto.getMyprice();
     }
 }

--- a/src/main/java/com/sparta/myselectshop/entity/Product.java
+++ b/src/main/java/com/sparta/myselectshop/entity/Product.java
@@ -1,0 +1,40 @@
+package com.sparta.myselectshop.entity;
+
+import com.sparta.myselectshop.dto.ProductRequestDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity // JPA가 관리하는 Entity 클래스로 지정
+@Getter // Lombok 라이브러리를 사용하여 쉽게 필드를 가져올 수 있는 Get 메서드 제공
+@Setter // Lombok 라이브러리를 사용하여 쉽게 필드값을 수정할 수 있는 Set 메서드 제공
+@NoArgsConstructor // 기본 생성자를 직접 작성하지 않아도 자동으로 적용해줌
+@Table(name = "product") // DB에서 매핑할 테이블의 이름을 지정
+public class Product extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String image;
+
+    @Column(nullable = false)
+    private String link;
+
+    @Column(nullable = false)
+    private int lprice;
+
+    @Column(nullable = false)
+    private int myprice;
+
+    public Product(ProductRequestDto requestDto) {
+        this.title = requestDto.getTitle();
+        this.image = requestDto.getImage();
+        this.link = requestDto.getLink();
+        this.lprice = requestDto.getLprice();
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/entity/TimeStamped.java
+++ b/src/main/java/com/sparta/myselectshop/entity/TimeStamped.java
@@ -1,0 +1,26 @@
+package com.sparta.myselectshop.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // 해당 추상 클래스를 상속받는 Entity는 아래 멤버변수를 컬럼으로 자동 인식됨
+@EntityListeners(AuditingEntityListener.class) // Auditing(감사)는 데이터 생성,수정,삭제 등 변경 사항을 추적하는 기능
+public abstract class TimeStamped {
+    // Auditing(감사)을 하는 TimeStamped는 따로 인스턴스를 생성할 필요가 없기에 추상 클래스로 선언하여 생성을 막음.
+    @CreatedDate // Entity 객체가 생성되어 저장될 때의 시간을 자동 저장
+    @Column(updatable = false)
+    @Temporal(TemporalType.TIMESTAMP) // 날짜 타입 매핑할 때 사용하는 애너테이션
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate // Entity 객체가 수정될 때 수정된 시간을 자동 저장
+    @Column
+    @Temporal(TemporalType.TIMESTAMP) // 날짜 타입 매핑할 때 사용하는 애너테이션
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/sparta/myselectshop/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/myselectshop/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.myselectshop.repository;
+
+import com.sparta.myselectshop.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+}

--- a/src/main/java/com/sparta/myselectshop/service/ProductService.java
+++ b/src/main/java/com/sparta/myselectshop/service/ProductService.java
@@ -1,0 +1,24 @@
+package com.sparta.myselectshop.service;
+
+import com.sparta.myselectshop.dto.ProductRequestDto;
+import com.sparta.myselectshop.dto.ProductResponseDto;
+import com.sparta.myselectshop.entity.Product;
+import com.sparta.myselectshop.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    // 관심상품 등록 API
+    public ProductResponseDto createProduct(ProductRequestDto requestDto) {
+        // RequestDTO -> Entity -> save
+        Product savedProduct = productRepository.save(new Product(requestDto));
+
+        // savedEntity -> ResponseDTO
+        return new ProductResponseDto(savedProduct);
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/service/ProductService.java
+++ b/src/main/java/com/sparta/myselectshop/service/ProductService.java
@@ -1,17 +1,24 @@
 package com.sparta.myselectshop.service;
 
+import com.sparta.myselectshop.dto.ProductMypriceRequestDto;
 import com.sparta.myselectshop.dto.ProductRequestDto;
 import com.sparta.myselectshop.dto.ProductResponseDto;
 import com.sparta.myselectshop.entity.Product;
 import com.sparta.myselectshop.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ProductService {
 
     private final ProductRepository productRepository;
+
+    // 최저가 설정 최소 금액
+    public static final int MIN_MY_PRICE = 100;
 
     // 관심상품 등록 API
     public ProductResponseDto createProduct(ProductRequestDto requestDto) {
@@ -20,5 +27,27 @@ public class ProductService {
 
         // savedEntity -> ResponseDTO
         return new ProductResponseDto(savedProduct);
+    }
+
+    // 관심상품 희망 최저가 업데이트 API
+    @Transactional
+    public ProductResponseDto updateProduct(Long id, ProductMypriceRequestDto requestDto) {
+        // 희망하는 최저가
+        int myprice = requestDto.getMyprice();
+
+        // 최저가 설정이 가능한 금액인지(100원 이상) 검증
+        if (myprice < MIN_MY_PRICE) {
+            throw new IllegalArgumentException("유효하지 않은 관심 가격입니다. 최소 " + MIN_MY_PRICE + "이상으로 설정해 주세요.");
+        }
+
+        // 최저가 업데이트를 원하는 해당 상품 조회
+        Product product = productRepository.findById(id).orElseThrow(() ->
+            new IllegalArgumentException("해당 상품이 존재하지 않습니다.")
+        );
+        
+        // 해당 상품의 희망하는 최저가 금액 설정
+        product.update(requestDto);
+
+        return new ProductResponseDto(product);
     }
 }


### PR DESCRIPTION
NAVER 상품 검색 API를 사용하여 조회된 상품을 관심 상품으로 등록하는 기능 추가
- JPA Auditing 기능을 적용하여 관심 상품 등록 시 생성 시간, 수정 시간 컬럼으로 자동 적용

검색한 상품의 희망 최저가를 설정하는 기능 추가
- Naver 검색 API를 사용하여 검색한 상품 목록 중 해당 상품의 희망하는 최저가를 설정할 수 있도록 구현