### PR TITLE
[Feat]: 관심상품 폴더 기능 추가

### DIFF
--- a/src/main/java/com/sparta/myselectshop/controller/FolderController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/FolderController.java
@@ -1,0 +1,29 @@
+package com.sparta.myselectshop.controller;
+
+import com.sparta.myselectshop.dto.FolderRequestDto;
+import com.sparta.myselectshop.security.UserDetailsImpl;
+import com.sparta.myselectshop.service.FolderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class FolderController {
+
+    private final FolderService folderService;
+
+    @PostMapping("/folders")
+    public void addFolders(@RequestBody FolderRequestDto folderRequestDto,
+                           @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<String> folderNames = folderRequestDto.getFolderNames();
+
+        folderService.addFolders(folderNames, userDetails.getUser());
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/controller/FolderController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/FolderController.java
@@ -1,14 +1,12 @@
 package com.sparta.myselectshop.controller;
 
 import com.sparta.myselectshop.dto.FolderRequestDto;
+import com.sparta.myselectshop.dto.FolderResponseDto;
 import com.sparta.myselectshop.security.UserDetailsImpl;
 import com.sparta.myselectshop.service.FolderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -19,6 +17,7 @@ public class FolderController {
 
     private final FolderService folderService;
 
+    // 폴더 생성 API
     @PostMapping("/folders")
     public void addFolders(@RequestBody FolderRequestDto folderRequestDto,
                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -26,4 +25,11 @@ public class FolderController {
 
         folderService.addFolders(folderNames, userDetails.getUser());
     }
+
+    // 폴더 조회 API
+    @GetMapping("/folders")
+    public List<FolderResponseDto> getFolders(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return folderService.getFolders(userDetails.getUser());
+    }
+
 }

--- a/src/main/java/com/sparta/myselectshop/controller/ProductController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/ProductController.java
@@ -46,6 +46,7 @@ public class ProductController {
         );
     }
 
+    // 관심상품 폴더 등록 API
     @PostMapping("/products/{productId}/folder")
     public void addFolder(
             @PathVariable Long productId,
@@ -53,5 +54,20 @@ public class ProductController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         productService.addFolder(productId, folderId, userDetails.getUser());
+    }
+
+    // 폴더별 관심상품 조회 API
+    @GetMapping("/folders/{folderId}/products")
+    public Page<ProductResponseDto> getProductsInFolder(
+            @PathVariable Long folderId,
+            @RequestParam("page") int page,
+            @RequestParam("size") int size,
+            @RequestParam("sortBy") String sortBy,
+            @RequestParam("isAsc") boolean isAsc,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        return productService.getProductsInFolder(
+                folderId, page -1 , size, sortBy, isAsc, userDetails.getUser()
+        );
     }
 }

--- a/src/main/java/com/sparta/myselectshop/controller/ProductController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/ProductController.java
@@ -45,4 +45,13 @@ public class ProductController {
                 page-1, size, sortBy, isAsc
         );
     }
+
+    @PostMapping("/products/{productId}/folder")
+    public void addFolder(
+            @PathVariable Long productId,
+            @RequestParam Long folderId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        productService.addFolder(productId, folderId, userDetails.getUser());
+    }
 }

--- a/src/main/java/com/sparta/myselectshop/controller/UserController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/UserController.java
@@ -70,7 +70,7 @@ public class UserController {
         return new UserInfoDto(username, isAdmin);
     }
 
-    // 회원의 폴더 목록 조회 API
+    // 회원의 폴더 목록 조회 API(TemplateEngine을 통해 html에 적용)
     @GetMapping("/user-folder")
     public String getUserInfo(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         model.addAttribute("folders", folderService.getFolders(userDetails.getUser()));

--- a/src/main/java/com/sparta/myselectshop/controller/UserController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/UserController.java
@@ -4,12 +4,14 @@ import com.sparta.myselectshop.dto.SignupRequestDto;
 import com.sparta.myselectshop.dto.UserInfoDto;
 import com.sparta.myselectshop.entity.UserRoleEnum;
 import com.sparta.myselectshop.security.UserDetailsImpl;
+import com.sparta.myselectshop.service.FolderService;
 import com.sparta.myselectshop.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +28,7 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+    private final FolderService folderService;
 
     // 로그인 페이지 반환 API
     @GetMapping("/user/login-page")
@@ -65,5 +68,13 @@ public class UserController {
         boolean isAdmin = (role == UserRoleEnum.ADMIN);
 
         return new UserInfoDto(username, isAdmin);
+    }
+
+    // 회원의 폴더 목록 조회 API
+    @GetMapping("/user-folder")
+    public String getUserInfo(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        model.addAttribute("folders", folderService.getFolders(userDetails.getUser()));
+
+        return "index :: #fragment";
     }
 }

--- a/src/main/java/com/sparta/myselectshop/dto/FolderRequestDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/FolderRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.myselectshop.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FolderRequestDto {
+    List<String> folderNames;
+}

--- a/src/main/java/com/sparta/myselectshop/dto/FolderResponseDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/FolderResponseDto.java
@@ -1,0 +1,15 @@
+package com.sparta.myselectshop.dto;
+
+import com.sparta.myselectshop.entity.Folder;
+import lombok.Getter;
+
+@Getter
+public class FolderResponseDto {
+    private Long id;
+    private String name;
+
+    public FolderResponseDto(Folder folder) {
+        this.id = folder.getId();
+        this.name = folder.getName();
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/dto/ProductResponseDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/ProductResponseDto.java
@@ -1,8 +1,13 @@
 package com.sparta.myselectshop.dto;
 
+import com.sparta.myselectshop.entity.Folder;
 import com.sparta.myselectshop.entity.Product;
+import com.sparta.myselectshop.entity.ProductFolder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -14,6 +19,8 @@ public class ProductResponseDto {
     private int lprice;
     private int myprice;
 
+    private List<FolderResponseDto> productFolderList = new ArrayList<>();
+
     public ProductResponseDto(Product product) {
         this.id = product.getId();
         this.title = product.getTitle();
@@ -21,5 +28,10 @@ public class ProductResponseDto {
         this.image = product.getImage();
         this.lprice = product.getLprice();
         this.myprice = product.getMyprice();
+
+        for (ProductFolder productFolder : product.getProductFolderList()) {
+            Folder folder = productFolder.getFolder();
+            productFolderList.add(new FolderResponseDto(folder));
+        }
     }
 }

--- a/src/main/java/com/sparta/myselectshop/entity/Folder.java
+++ b/src/main/java/com/sparta/myselectshop/entity/Folder.java
@@ -1,0 +1,28 @@
+package com.sparta.myselectshop.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "folder")
+public class Folder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public Folder(String name, User user) {
+        this.name = name;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/entity/Product.java
+++ b/src/main/java/com/sparta/myselectshop/entity/Product.java
@@ -6,6 +6,9 @@ import com.sparta.myselectshop.naver.dto.ItemDto;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity // JPA가 관리하는 Entity 클래스로 지정
 @Getter // Lombok 라이브러리를 사용하여 쉽게 필드를 가져올 수 있는 Get 메서드 제공
@@ -36,6 +39,9 @@ public class Product extends TimeStamped {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "product")
+    private List<ProductFolder> folderList = new ArrayList<>();
 
     public Product(ProductRequestDto requestDto, User user) {
         this.title = requestDto.getTitle();

--- a/src/main/java/com/sparta/myselectshop/entity/Product.java
+++ b/src/main/java/com/sparta/myselectshop/entity/Product.java
@@ -41,7 +41,7 @@ public class Product extends TimeStamped {
     private User user;
 
     @OneToMany(mappedBy = "product")
-    private List<ProductFolder> folderList = new ArrayList<>();
+    private List<ProductFolder> productFolderList = new ArrayList<>();
 
     public Product(ProductRequestDto requestDto, User user) {
         this.title = requestDto.getTitle();

--- a/src/main/java/com/sparta/myselectshop/entity/ProductFolder.java
+++ b/src/main/java/com/sparta/myselectshop/entity/ProductFolder.java
@@ -2,10 +2,10 @@ package com.sparta.myselectshop.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor
 @Table(name = "product_folder")
 @Entity
 public class ProductFolder {
@@ -20,4 +20,9 @@ public class ProductFolder {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "folder_id", nullable = false)
     private Folder folder;
+
+    public ProductFolder(Product product, Folder folder) {
+        this.product = product;
+        this.folder = folder;
+    }
 }

--- a/src/main/java/com/sparta/myselectshop/entity/ProductFolder.java
+++ b/src/main/java/com/sparta/myselectshop/entity/ProductFolder.java
@@ -1,0 +1,23 @@
+package com.sparta.myselectshop.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Table(name = "product_folder")
+@Entity
+public class ProductFolder {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "folder_id", nullable = false)
+    private Folder folder;
+}

--- a/src/main/java/com/sparta/myselectshop/repository/FolderRepository.java
+++ b/src/main/java/com/sparta/myselectshop/repository/FolderRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.myselectshop.repository;
+
+import com.sparta.myselectshop.entity.Folder;
+import com.sparta.myselectshop.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+
+    List<Folder> findAllByUserAndNameIn(User user, Collection<String> names);
+}

--- a/src/main/java/com/sparta/myselectshop/repository/FolderRepository.java
+++ b/src/main/java/com/sparta/myselectshop/repository/FolderRepository.java
@@ -8,6 +8,9 @@ import java.util.Collection;
 import java.util.List;
 
 public interface FolderRepository extends JpaRepository<Folder, Long> {
-
+    // 해당 User가 가진 전체 folder 목록 중 인자로 전달받은 names와 일치한 name을 가진 Folder를 List로 반환
+    // select * from folder where user_id = ? and name in (?, ?, ?);
     List<Folder> findAllByUserAndNameIn(User user, Collection<String> names);
+
+    List<Folder> findAllByUser(User user);
 }

--- a/src/main/java/com/sparta/myselectshop/repository/ProductFolderRepository.java
+++ b/src/main/java/com/sparta/myselectshop/repository/ProductFolderRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.myselectshop.repository;
+
+import com.sparta.myselectshop.entity.ProductFolder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductFolderRepository extends JpaRepository<ProductFolder, Long> {
+}

--- a/src/main/java/com/sparta/myselectshop/repository/ProductFolderRepository.java
+++ b/src/main/java/com/sparta/myselectshop/repository/ProductFolderRepository.java
@@ -1,7 +1,12 @@
 package com.sparta.myselectshop.repository;
 
+import com.sparta.myselectshop.entity.Folder;
+import com.sparta.myselectshop.entity.Product;
 import com.sparta.myselectshop.entity.ProductFolder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ProductFolderRepository extends JpaRepository<ProductFolder, Long> {
+    Optional<ProductFolder> findByProductAndFolder(Product product, Folder folder);
 }

--- a/src/main/java/com/sparta/myselectshop/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/myselectshop/repository/ProductRepository.java
@@ -6,9 +6,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Page<Product> findAllByUser(User user, Pageable pageable);
+
+    Page<Product> findAllByUserAndProductFolderList_FolderId(User user, Long folderId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/myselectshop/service/FolderService.java
+++ b/src/main/java/com/sparta/myselectshop/service/FolderService.java
@@ -1,0 +1,48 @@
+package com.sparta.myselectshop.service;
+
+import com.sparta.myselectshop.entity.Folder;
+        import com.sparta.myselectshop.entity.User;
+import com.sparta.myselectshop.repository.FolderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class FolderService {
+
+    private final FolderRepository folderRepository;
+
+    public void addFolders(List<String> folderNames, User user) {
+        // 해당 User의 Folder 목록 중 인자로 전달한 names와 일치한 name을 가진 Folder만 가져옴
+        List<Folder> existFolderList = folderRepository.findAllByUserAndNameIn(user, folderNames);
+
+        // 중복되지 않는 경우 해당 Folder를 저장하기 위한 리스트
+        List<Folder> folderList = new ArrayList<>();
+
+        // 사용자가 전달한 Folder 이름과 기존 존재하는 Folder의 이름이 일치하지 않을 경우 Folder 생성 및 저장
+        for (String folderName : folderNames) {
+            if (!isExsistFolderName(folderName, existFolderList)) {
+                 Folder folder = new Folder(folderName, user);
+                 folderList.add(folder);
+            } else {
+                throw new IllegalArgumentException("이미 존재하는 폴더입니다.");
+            }
+        }
+
+        // 폴더 이름이 중복 되지 않는 폴더만 저장
+        folderRepository.saveAll(folderList);
+    }
+
+    // 사용자가 전달한 Folder 이름과 일치한 리스트 중 name 값이 일치한 Folder가 있는지 검증
+    private boolean isExsistFolderName(String folderName, List<Folder> existFolderList) {
+        for (Folder folder : existFolderList) {
+            if (folderName.equals(folder.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/service/FolderService.java
+++ b/src/main/java/com/sparta/myselectshop/service/FolderService.java
@@ -1,7 +1,8 @@
 package com.sparta.myselectshop.service;
 
+import com.sparta.myselectshop.dto.FolderResponseDto;
 import com.sparta.myselectshop.entity.Folder;
-        import com.sparta.myselectshop.entity.User;
+import com.sparta.myselectshop.entity.User;
 import com.sparta.myselectshop.repository.FolderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public class FolderService {
 
     private final FolderRepository folderRepository;
 
+    // 사용자 폴더 생성 API
     public void addFolders(List<String> folderNames, User user) {
         // 해당 User의 Folder 목록 중 인자로 전달한 names와 일치한 name을 가진 Folder만 가져옴
         List<Folder> existFolderList = folderRepository.findAllByUserAndNameIn(user, folderNames);
@@ -36,7 +38,20 @@ public class FolderService {
         folderRepository.saveAll(folderList);
     }
 
-    // 사용자가 전달한 Folder 이름과 일치한 리스트 중 name 값이 일치한 Folder가 있는지 검증
+    // 사용자 폴더 조회 API
+    public List<FolderResponseDto> getFolders(User user) {
+        List<Folder> folderList = folderRepository.findAllByUser(user);
+
+        List<FolderResponseDto> responseDtoList = new ArrayList<>();
+
+        for (Folder folder : folderList) {
+            responseDtoList.add(new FolderResponseDto(folder));
+        }
+
+        return responseDtoList;
+    }
+
+    // 폴더명 중복 검증 메서드
     private boolean isExsistFolderName(String folderName, List<Folder> existFolderList) {
         for (Folder folder : existFolderList) {
             if (folderName.equals(folder.getName())) {

--- a/src/main/java/com/sparta/myselectshop/service/ProductService.java
+++ b/src/main/java/com/sparta/myselectshop/service/ProductService.java
@@ -68,7 +68,11 @@ public class ProductService {
 
         product.updateByItemDto(itemDto);
     }
+
     // 관심상품 조회 API
+    // 관심 상품(Product)를 가져올 때 연관된 폴더(Folder) 리스트가 포함되어 있는데 폴더를 조회하는 시점을 필요에 따라 조회로 가정
+    // 1:N 관계 default FetchType은 Lazy(지연 로딩)이므로 트랜잭션 환경이 필요함(수정/삭제)가 아니기에 readOnly 옵션 적용
+    @Transactional(readOnly = true)
     public Page<ProductResponseDto> getProducts(User user, int page, int size, String sortBy, boolean isAsc) {
         // 상품 데이터 페이징 및 정렬
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;

--- a/src/main/java/com/sparta/myselectshop/service/ProductService.java
+++ b/src/main/java/com/sparta/myselectshop/service/ProductService.java
@@ -3,10 +3,10 @@ package com.sparta.myselectshop.service;
 import com.sparta.myselectshop.dto.ProductMypriceRequestDto;
 import com.sparta.myselectshop.dto.ProductRequestDto;
 import com.sparta.myselectshop.dto.ProductResponseDto;
-import com.sparta.myselectshop.entity.Product;
-import com.sparta.myselectshop.entity.User;
-import com.sparta.myselectshop.entity.UserRoleEnum;
+import com.sparta.myselectshop.entity.*;
 import com.sparta.myselectshop.naver.dto.ItemDto;
+import com.sparta.myselectshop.repository.FolderRepository;
+import com.sparta.myselectshop.repository.ProductFolderRepository;
 import com.sparta.myselectshop.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,14 +16,15 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final FolderRepository folderRepository;
+    private final ProductFolderRepository productFolderRepository;
 
     // 최저가 설정 최소 금액
     public static final int MIN_MY_PRICE = 100;
@@ -94,5 +95,31 @@ public class ProductService {
 
         // Page<Product> 타입의 리스트를 map 을 사용하여 Page<ProductResponseDto> 타입으로 변환 후 반환
         return productList.map(ProductResponseDto::new);
+    }
+
+
+    public void addFolder(Long productId, Long folderId, User user) {
+        Product product = productRepository.findById(productId).orElseThrow(
+                () -> new NullPointerException("해당 상품이 존재하지 않습니다.")
+        );
+
+        Folder folder = folderRepository.findById(folderId).orElseThrow(
+                () -> new NullPointerException("해당 폴더가 존재하지 않습니다.")
+        );
+
+        // Product와 Folder 사용자 검증(User)
+        if (!product.getUser().getId().equals(user.getId()) || !folder.getUser().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("회원님의 관심 상품이 아니거나, 회원님의 폴더가 아닙니다.");
+        }
+
+        // 해당 폴더에 해당 상품을 이미 추가했는지 검증
+        Optional<ProductFolder> overLapFolder = productFolderRepository.findByProductAndFolder(product, folder);
+
+        if (overLapFolder.isPresent()) {
+            throw new IllegalArgumentException("중복된 폴더입니다.");
+        }
+
+        // 상품, 폴더 중간 테이블에 저장
+        productFolderRepository.save(new ProductFolder(product, folder));
     }
 }

--- a/src/main/java/com/sparta/myselectshop/service/ProductService.java
+++ b/src/main/java/com/sparta/myselectshop/service/ProductService.java
@@ -9,6 +9,7 @@ import com.sparta.myselectshop.repository.FolderRepository;
 import com.sparta.myselectshop.repository.ProductFolderRepository;
 import com.sparta.myselectshop.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.query.SortDirection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -97,7 +99,7 @@ public class ProductService {
         return productList.map(ProductResponseDto::new);
     }
 
-
+    // 관심상품 폴더 등록 API
     public void addFolder(Long productId, Long folderId, User user) {
         Product product = productRepository.findById(productId).orElseThrow(
                 () -> new NullPointerException("해당 상품이 존재하지 않습니다.")
@@ -121,5 +123,19 @@ public class ProductService {
 
         // 상품, 폴더 중간 테이블에 저장
         productFolderRepository.save(new ProductFolder(product, folder));
+    }
+
+    // 폴더별 관심상품 목록 조회 API
+    public Page<ProductResponseDto> getProductsInFolder(Long folderId, int page, int size, String sortBy, boolean isAsc, User user) {
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        // 해당 User의 특정 폴더에 담긴 관심 상품 조회 -> folder_id를 사용하여 중간 테이블에 있는 해당 folder_id와 연결된 product_id를 페이징 처리하여 가져옴
+        Page<Product> productList = productRepository.findAllByUserAndProductFolderList_FolderId(user, folderId, pageable);
+
+        Page<ProductResponseDto> responseDtoList = productList.map(ProductResponseDto::new);
+
+        return responseDtoList;
     }
 }

--- a/src/main/resources/static/js/basic.js
+++ b/src/main/resources/static/js/basic.js
@@ -1,5 +1,6 @@
 const host = 'http://' + window.location.host;
 let targetId;
+let folderTargetId;
 
 $(document).ready(function () {
     const auth = getToken();
@@ -34,6 +35,18 @@ $(document).ready(function () {
             } else {
                 showProduct();
             }
+
+            // 로그인한 유저의 폴더
+            $.ajax({
+                type: 'GET',
+                url: `/api/user-folder`,
+                error(error) {
+                    logout();
+                }
+            }).done(function (fragment) {
+                $('#fragment').replaceWith(fragment);
+            });
+
         })
         .fail(function (jqXHR, textStatus) {
             logout();
@@ -157,7 +170,7 @@ function addProduct(itemDto) {
     });
 }
 
-function showProduct() {
+function showProduct(folderId = null) {
     /**
      * 관심상품 목록: #product-container
      * 검색결과 목록: #search-result-box
@@ -169,7 +182,13 @@ function showProduct() {
     var sorting = $("#sorting option:selected").val();
     var isAsc = $(':radio[name="isAsc"]:checked').val();
 
-    dataSource = `/api/products?sortBy=${sorting}&isAsc=${isAsc}`;
+    if (folderId) {
+        dataSource = `/api/folders/${folderId}/products?sortBy=${sorting}&isAsc=${isAsc}`;
+    } else if(folderTargetId === undefined) {
+        dataSource = `/api/products?sortBy=${sorting}&isAsc=${isAsc}&folderId=${folderId}`;
+    } else {
+        dataSource = `/api/folders/${folderTargetId}/products?sortBy=${sorting}&isAsc=${isAsc}`;
+    }
 
     $('#product-container').empty();
     $('#search-result-box').empty();
@@ -187,6 +206,9 @@ function showProduct() {
         showPrevious: true,
         showNext: true,
         ajax: {
+            beforeSend: function () {
+                $('#product-container').html('상품 불러오는 중...');
+            },
             error(error, status, request) {
                 if (error.status === 403) {
                     $('html').html(error.responseText);
@@ -195,7 +217,7 @@ function showProduct() {
                 logout();
             }
         },
-        callback: function(response, pagination) {
+        callback: function (response, pagination) {
             $('#product-container').empty();
             for (let i = 0; i < response.length; i++) {
                 let product = response[i];
@@ -206,8 +228,85 @@ function showProduct() {
     });
 }
 
+// Folder 관련 기능
+function openFolder(folderId) {
+    folderTargetId = folderId;
+    $("button.product-folder").removeClass("folder-active");
+    if (!folderId) {
+        $("button#folder-all").addClass('folder-active');
+    } else {
+        $(`button[value='${folderId}']`).addClass('folder-active');
+    }
+    showProduct(folderId);
+}
+
+// 폴더 추가 팝업
+function openAddFolderPopup() {
+    $('#container2').addClass('active');
+}
+
+// 폴더 Input 추가
+function addFolderInput() {
+    $('#folders-input').append(
+        `<input type="text" class="folderToAdd" placeholder="추가할 폴더명">
+       <span onclick="closeFolderInput(this)" style="margin-right:5px">
+            <svg xmlns="http://www.w3.org/2000/svg" width="30px" fill="red" class="bi bi-x-circle-fill" viewBox="0 0 16 16">
+              <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.354 4.646a.5.5 0 1 0-.708.708L7.293 8l-2.647 2.646a.5.5 0 0 0 .708.708L8 8.707l2.646 2.647a.5.5 0 0 0 .708-.708L8.707 8l2.647-2.646a.5.5 0 0 0-.708-.708L8 7.293 5.354 4.646z"/>
+            </svg>
+       </span>
+      `
+    );
+}
+
+function closeFolderInput(folder) {
+    $(folder).prev().remove();
+    $(folder).next().remove();
+    $(folder).remove();
+}
+
+function addFolder() {
+    const folderNames = $('.folderToAdd').toArray().map(input => input.value);
+    try {
+        folderNames.forEach(name => {
+            if (name === '') {
+                alert('올바른 폴더명을 입력해주세요');
+                throw new Error("stop loop");
+            }
+        });
+    } catch (e) {
+        console.log(e);
+        return;
+    }
+
+    $.ajax({
+        type: "POST",
+        url: `/api/folders`,
+        contentType: "application/json",
+        data: JSON.stringify({
+            folderNames
+        })
+    }).done(function (data, textStatus, xhr) {
+        if(data !== '') {
+            alert("중복된 폴더입니다.");
+            return;
+        }
+        $('#container2').removeClass('active');
+        alert('성공적으로 등록되었습니다.');
+        window.location.reload();
+    })
+        .fail(function(xhr, textStatus, errorThrown) {
+            alert("중복된 폴더입니다.");
+        });
+}
+
 function addProductItem(product) {
-    console.log(product)
+    const folders = product.productFolderList.map(folder =>
+        `
+            <span onclick="openFolder(${folder.id})">
+                #${folder.name}
+            </span>
+        `
+    );
     return `<div class="product-card">
                 <div onclick="window.location.href='${product.link}'">
                     <div class="card-header">
@@ -226,7 +325,59 @@ function addProductItem(product) {
                         </div>
                     </div>
                 </div>
+                <div class="product-tags" style="margin-bottom: 20px;">
+                    ${folders}
+                    <span onclick="addInputForProductToFolder(${product.id}, this)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="30px" fill="currentColor" class="bi bi-folder-plus" viewBox="0 0 16 16">
+                            <path d="M.5 3l.04.87a1.99 1.99 0 0 0-.342 1.311l.637 7A2 2 0 0 0 2.826 14H9v-1H2.826a1 1 0 0 1-.995-.91l-.637-7A1 1 0 0 1 2.19 4h11.62a1 1 0 0 1 .996 1.09L14.54 8h1.005l.256-2.819A2 2 0 0 0 13.81 3H9.828a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 6.172 1H2.5a2 2 0 0 0-2 2zm5.672-1a1 1 0 0 1 .707.293L7.586 3H2.19c-.24 0-.47.042-.684.12L1.5 2.98a1 1 0 0 1 1-.98h3.672z"/>
+                            <path d="M13.5 10a.5.5 0 0 1 .5.5V12h1.5a.5.5 0 0 1 0 1H14v1.5a.5.5 0 0 1-1 0V13h-1.5a.5.5 0 0 1 0-1H13v-1.5a.5.5 0 0 1 .5-.5z"/>
+                        </svg>
+                    </span>
+                </div>
             </div>`;
+}
+
+function addInputForProductToFolder(productId, button) {
+    $.ajax({
+        type: 'GET',
+        url: `/api/folders`,
+        success: function (folders) {
+            const options = folders.map(folder => `<option value="${folder.id}">${folder.name}</option>`)
+            const form = `
+                <span>
+                    <form id="folder-select" method="post" autocomplete="off" action="/api/products/${productId}/folder">
+                        <select name="folderId" form="folder-select">
+                            ${options}
+                        </select>
+                        <input type="submit" value="추가" style="padding: 5px; font-size: 12px; margin-left: 5px;">
+                    </form>
+                </span>
+            `;
+            $(form).insertBefore(button);
+            $(button).remove();
+            $("#folder-select").on('submit', function (e) {
+                e.preventDefault();
+                $.ajax({
+                    type: $(this).prop('method'),
+                    url: $(this).prop('action'),
+                    data: $(this).serialize(),
+                }).done(function (data, textStatus, xhr) {
+                    if(data !== '') {
+                        alert("중복된 폴더입니다.");
+                        return;
+                    }
+                    alert('성공적으로 등록되었습니다.');
+                    window.location.reload();
+                })
+                    .fail(function(xhr, textStatus, errorThrown) {
+                        alert("중복된 폴더입니다.");
+                    });
+            });
+        },
+        error(error, status, request) {
+            logout();
+        }
+    });
 }
 
 function setMyprice() {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -39,6 +39,28 @@
   </div>
 </div>
 <div id="see-area">
+  <div class="folder-bar folder-black">
+    <div>
+      <button id="folder-all" class="folder-bar-item folder-button product-folder folder-active" onclick="openFolder()">전체</button>
+    </div>
+    <div id="fragment">
+      <div th:each="folder : ${folders}">
+        <button class="folder-bar-item folder-button product-folder"
+                th:value="${folder.id}"
+                th:utext="${folder.name}"
+                th:attr="onclick=|openFolder(${folder.id})|">
+        </button>
+      </div>
+    </div>
+    <div>
+      <button id="folder-add" class="folder-bar-item folder-button product-folder" onclick="openAddFolderPopup()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="30px" fill="currentColor" class="bi bi-folder-plus" viewBox="0 0 16 16">
+          <path d="M.5 3l.04.87a1.99 1.99 0 0 0-.342 1.311l.637 7A2 2 0 0 0 2.826 14H9v-1H2.826a1 1 0 0 1-.995-.91l-.637-7A1 1 0 0 1 2.19 4h11.62a1 1 0 0 1 .996 1.09L14.54 8h1.005l.256-2.819A2 2 0 0 0 13.81 3H9.828a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 6.172 1H2.5a2 2 0 0 0-2 2zm5.672-1a1 1 0 0 1 .707.293L7.586 3H2.19c-.24 0-.47.042-.684.12L1.5 2.98a1 1 0 0 1 1-.98h3.672z"/>
+          <path d="M13.5 10a.5.5 0 0 1 .5.5V12h1.5a.5.5 0 0 1 0 1H14v1.5a.5.5 0 0 1-1 0V13h-1.5a.5.5 0 0 1 0-1H13v-1.5a.5.5 0 0 1 .5-.5z"/>
+        </svg>
+      </button>
+    </div>
+  </div>
   <div class="pagination">
     정렬:
     <select id="sorting" onchange="showProduct()">
@@ -52,7 +74,26 @@
   <div id="pagination" class="pagination"></div>
   <br>
   <div id="product-container">
-
+  </div>
+  <div id="container2" class="popup-container">
+    <div class="popup" style="width:410px; height:auto">
+      <button id="close2" class="close">
+        X
+      </button>
+      <h1>🗂 폴더 추가하기</h1>
+      <p>폴더를 추가해서 관심상품을 관리해보세요!</p>
+      <div id="folders-input">
+        <input type="text" class="folderToAdd" placeholder="추가할 폴더명">
+        <!--                <div class="control" data-v-79d84978="" style="width:20px"><a class="button is-primary is-outlined" data-v-79d84978=""><span class="icon" data-v-79d84978=""><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512" class="svg-inline&#45;&#45;fa fa-times fa-w-11" data-v-79d84978=""><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z" data-v-79d84978="" class=""></path></svg></span></a></div>-->
+      </div>
+      <div onclick="addFolderInput()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="30px" fill="currentColor" class="bi bi-folder-plus" viewBox="0 0 16 16">
+          <path d="M.5 3l.04.87a1.99 1.99 0 0 0-.342 1.311l.637 7A2 2 0 0 0 2.826 14H9v-1H2.826a1 1 0 0 1-.995-.91l-.637-7A1 1 0 0 1 2.19 4h11.62a1 1 0 0 1 .996 1.09L14.54 8h1.005l.256-2.819A2 2 0 0 0 13.81 3H9.828a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 6.172 1H2.5a2 2 0 0 0-2 2zm5.672-1a1 1 0 0 1 .707.293L7.586 3H2.19c-.24 0-.47.042-.684.12L1.5 2.98a1 1 0 0 1 1-.98h3.672z"/>
+          <path d="M13.5 10a.5.5 0 0 1 .5.5V12h1.5a.5.5 0 0 1 0 1H14v1.5a.5.5 0 0 1-1 0V13h-1.5a.5.5 0 0 1 0-1H13v-1.5a.5.5 0 0 1 .5-.5z"/>
+        </svg>
+      </div>
+      <button id="add-folder-btn" class="cta2" onclick="addFolder()">추가하기</button>
+    </div>
   </div>
 </div>
 <div id="search-area">


### PR DESCRIPTION
사용자 폴더 등록,조회 API 구현
- 관심 상품을 담을 수 있는 폴더 생성 및 조회 기능
- 사용자는 하나의 상품을 여러 폴더에 담을 수 있도록 폴더와 상품을 N:M 관계로 설정
- 중간 테이블을 직접 생성, 중간 테이블과 폴더 & 관심상품을 N:1 관계로 설정

관심상품 폴더 적용 API 구현
- 사용자의 관심상품을 등록된 폴더에 적용할 수 있는 기능
- 특정 폴더에 특정 관심상품이 존재할 경우 중복되지 않도록 검증 로직 구현

사용자가 등록한 폴더별 관심상품 조회 API 구현
- 사용자가 등록한 특정 폴더를 선택했을 때 해당 폴더에 담긴 관심상품 목록을 조회할 수 있는 기능
- 클라이언트로부터 page, size, sortBy, isAsc를 받아 페이징 및 정렬 후 데이터 반환